### PR TITLE
Add recipes for tracking trends

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ achiving that using the [`gh`][3] CLI.
 These example use the `gh api` subcommand instead of `gh pr list` to avoid
 missing data due to the `--limit` option.
 
-[3]: #todo
+[3]: https://cli.github.com/
 
 ### List all sized PRs
 
@@ -136,7 +136,11 @@ gh api \
   /repos/mattdowdell/pr-size/pulls\?state=closed \
   --paginate \
   --jq '.[]
-    | select(.merged_at > "2024-12-19T12:19:42Z" and .merged_at <= "2024-12-23T09:04:04Z" and .base.ref == "main")
+    | select(
+      .merged_at > "2024-12-19T12:19:42Z" and
+      .merged_at <= "2024-12-23T09:04:04Z" and
+      .base.ref == "main"
+    )
     | "PR #\(.number): Merged at: \(.merged_at), \(.labels[].name | select(. | startswith("size/")))"'
 ```
 
@@ -167,7 +171,7 @@ gh api \
   /repos/mattdowdell/pr-size/pulls\?state=closed \
   --paginate \
   --jq '[ .[] | select(.merged_at != null and .base.ref == "main") ]
-    | map({ number: .number, size: .labels[].name | select(. | startswith("size/")) })
+    | map({ size: .labels[].name | select(. | startswith("size/")) })
     | group_by(.size)
     | .[]
     | "\(length) x \(.[0].size)"'
@@ -193,8 +197,12 @@ branch between 2 dates for each size.
 gh api \
   /repos/mattdowdell/pr-size/pulls\?state=closed \
   --paginate \
-  --jq '[ .[] | select(.merged_at > "2024-12-19T12:19:42Z" and .merged_at <= "2024-12-23T09:04:04Z" and .base.ref == "main") ]
-    | map({ number: .number, size: .labels[].name | select(. | startswith("size/")) })
+  --jq '[ .[] | select(
+      .merged_at > "2024-12-19T12:19:42Z" and
+      .merged_at <= "2024-12-23T09:04:04Z" and
+      .base.ref == "main"
+    ) ]
+    | map({ size: .labels[].name | select(. | startswith("size/")) })
     | group_by(.size)
     | .[]
     | "\(length) x \(.[0].size)"'

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 A GitHub Action for labelling pull requests with size categories.
 
 <!-- TODO: Add picture -->
-<!-- 100 chars ------------------------------------------------------------------------------------>
 
 There is a limit to how much code can be effectively reviewed in a single pull
 request. A [Smartbear study][1] found that reviewing more than 200-400 lines
@@ -93,4 +92,141 @@ jobs:
 
 ## Recipes
 
-<!-- TODO: populate -->
+Labelling pull requests with a size is a good start, but the real value comes
+from tracking the size of changes over time. The below recipes are aimed at
+achiving that using the [`gh`][3] CLI.
+
+These example use the `gh api` subcommand instead of `gh pr list` to avoid
+missing data due to the `--limit` option.
+
+[3]: #todo
+
+### List all sized PRs
+
+The following lists all pull requests merged to the `main` branch with their
+respective size labels.
+
+```sh
+gh api \
+  /repos/mattdowdell/pr-size/pulls\?state=closed \
+  --paginate \
+  --jq '.[]
+    | select((.merged_at != null) and (.base.ref == "main"))
+    | "PR #\(.number): Merged at: \(.merged_at), \(.labels[].name | select(. | startswith("size/")))"'
+```
+
+Example output:
+
+```text
+PR #27: Merged at: 2024-12-23T09:04:04Z, size/M
+PR #26: Merged at: 2024-12-21T11:34:34Z, size/XXL
+PR #23: Merged at: 2024-12-20T10:05:25Z, size/XL
+PR #21: Merged at: 2024-12-23T09:35:51Z, size/M
+PR #15: Merged at: 2024-12-19T12:19:42Z, size/S
+```
+
+### List sized PRs between 2 points
+
+It can be useful to track the size of changes between 2 points in time, e.g. the
+changes going into an upcoming release. The below lists the pull requests merged
+to the `main` branch between 2 dates with their respective size labels.
+
+```sh
+gh api \
+  /repos/mattdowdell/pr-size/pulls\?state=closed \
+  --paginate \
+  --jq '.[]
+    | select(.merged_at > "2024-12-19T12:19:42Z" and .merged_at <= "2024-12-23T09:04:04Z" and .base.ref == "main")
+    | "PR #\(.number): Merged at: \(.merged_at), \(.labels[].name | select(. | startswith("size/")))"'
+```
+
+If the pull requests between 2 commits or tags are preferred, each date can be
+identified with the following and substituted in:
+
+```sh
+git show --no-patch --date=format:'%Y-%m-%dT%H:%M:%S' --format=%cd <commit-or-tag>
+```
+
+Example output:
+
+```text
+PR #27: Merged at: 2024-12-23T09:04:04Z, size/M
+PR #26: Merged at: 2024-12-21T11:34:34Z, size/XXL
+PR #23: Merged at: 2024-12-20T10:05:25Z, size/XL
+```
+
+### Count frequency of sizes over all PRs
+
+Drilling down into the sizes of individual pull requests can help understand why
+it was a particular size. However, it is also useful to track trends over time,
+such as how many pull requests of each size have been merged. The below counts
+the number of pull requests merged to the `main` branch for each size.
+
+```sh
+gh api \
+  /repos/mattdowdell/pr-size/pulls\?state=closed \
+  --paginate \
+  --jq '[ .[] | select(.merged_at != null and .base.ref == "main") ]
+    | map({ number: .number, size: .labels[].name | select(. | startswith("size/")) })
+    | group_by(.size)
+    | .[]
+    | "\(length) x \(.[0].size)"'
+```
+
+Example output:
+
+```text
+2 x size/M
+1 x size/S
+1 x size/XL
+1 x size/XXL
+```
+
+### Count frequency of sizes between dates
+
+Comparing of the size of changes across multiple releases can help identify
+trends, including the number of changes in a release and the sizes of those
+changes. The below counts the number of pull requests merged to the `main`
+branch between 2 dates for each size.
+
+```sh
+gh api \
+  /repos/mattdowdell/pr-size/pulls\?state=closed \
+  --paginate \
+  --jq '[ .[] | select(.merged_at > "2024-12-19T12:19:42Z" and .merged_at <= "2024-12-23T09:04:04Z" and .base.ref == "main") ]
+    | map({ number: .number, size: .labels[].name | select(. | startswith("size/")) })
+    | group_by(.size)
+    | .[]
+    | "\(length) x \(.[0].size)"'
+```
+
+See [above](#list-sized-prs-between-2-points) for how to convert commits and
+tags into dates.
+
+Example output:
+
+```text
+1 x size/M
+1 x size/XL
+1 x size/XXL
+```
+
+### List PRs with a specific size
+
+It is not impossible for a change to be large out of necessity, even whilst
+striving for smaller pull requests. The below will list all pull requests merged
+to the `main` branch with a `size/XXL` label.
+
+```sh
+gh api \
+  /repos/mattdowdell/pr-size/pulls\?state=closed \
+  --jq '.[]
+    | select(.merged_at != null and .base.ref == "main" and .labels[].name == "size/XXL")
+    | "PR #\(.number)"'
+```
+
+Example output:
+
+```text
+PR #26
+```

--- a/README.md
+++ b/README.md
@@ -64,22 +64,25 @@ jobs:
 
 ## Inputs
 
-| Name           | Type   | Default      | Description                                                                  |
-| -------------- | ------ | ------------ | ---------------------------------------------------------------------------- |
-| `xs-threshold` | String | `10`         | The maximum number of lines changed for an extra small label to be assigned. |
-| `s-threshold`  | String | `100`        | The maximum number of lines changed for a small label to be assigned.        |
-| `m-threshold`  | String | `200`        | The maximum number of lines changed for a medium label to be assigned.       |
-| `l-threshold`  | String | `400`        | The maximum number of lines changed for a large label to be assigned.        |
-| `xl-threshold` | String | `800`        | The maximum number of lines changed for an extra large label to be assigned. |
-| `xs-label`     | String | `size/XS`    | The name of the label for a very small number of lines changed.              |
-| `s-label`      | String | `size/S`     | The name of the label for a small number of lines changed.                   |
-| `m-label`      | String | `size/M`     | The name of the label for a medium number of lines changed.                  |
-| `l-label`      | String | `size/L`     | The name of the label for a large number of lines changed.                   |
-| `xl-label`     | String | `size/XL`    | The name of the label for a very large number of lines changed.              |
-| `xxl-label`    | String | `size/XXL`   | The name of the label for a very, very large number of lines changed.        |
-| `github-token` | String | github.token | TODO                                                                         |
+| Name           | Type   | Default           | Description                                                                  |
+| -------------- | ------ | ----------------- | ---------------------------------------------------------------------------- |
+| `xs-threshold` | String | `10`              | The maximum number of lines changed for an extra small label to be assigned. |
+| `s-threshold`  | String | `100`             | The maximum number of lines changed for a small label to be assigned.        |
+| `m-threshold`  | String | `200`             | The maximum number of lines changed for a medium label to be assigned.       |
+| `l-threshold`  | String | `400`             | The maximum number of lines changed for a large label to be assigned.        |
+| `xl-threshold` | String | `800`             | The maximum number of lines changed for an extra large label to be assigned. |
+| `xs-label`     | String | `size/XS`         | The name of the label for a very small number of lines changed.              |
+| `s-label`      | String | `size/S`          | The name of the label for a small number of lines changed.                   |
+| `m-label`      | String | `size/M`          | The name of the label for a medium number of lines changed.                  |
+| `l-label`      | String | `size/L`          | The name of the label for a large number of lines changed.                   |
+| `xl-label`     | String | `size/XL`         | The name of the label for a very large number of lines changed.              |
+| `xxl-label`    | String | `size/XXL`        | The name of the label for a very, very large number of lines changed.        |
+| `github-token` | String | [github.token][3] | The token to use for managing labels.                                        |
 
 <!-- TODO: discuss how labels can be modified post-creation -->
+
+[3]:
+  https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication
 
 ## Outputs
 
@@ -94,12 +97,12 @@ jobs:
 
 Labelling pull requests with a size is a good start, but the real value comes
 from tracking the size of changes over time. The below recipes are aimed at
-achiving that using the [`gh`][3] CLI.
+achiving that using the [`gh`][4] CLI.
 
 These example use the `gh api` subcommand instead of `gh pr list` to avoid
 missing data due to the `--limit` option.
 
-[3]: https://cli.github.com/
+[4]: https://cli.github.com/
 
 ### List all sized PRs
 

--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ inputs:
     required: false
     default: 'size/XXL'
   github-token:
-    description: TODO
+    description: The token to use for managing labels.
     required: false
     default: ${{ github.token }}
 


### PR DESCRIPTION
Add some sample `gh` CLI commands to visualise the size of pull requests over time.

Fixes #25.